### PR TITLE
モックハンドラーを追加

### DIFF
--- a/src/components/functional/PrefectureName/index.test.tsx
+++ b/src/components/functional/PrefectureName/index.test.tsx
@@ -1,0 +1,14 @@
+import PrefectureName from '.';
+import { render, screen } from '@testing-library/react';
+
+describe('PrefectureName', () => {
+  describe('MSW が Jest 環境で動作していることを確認する', () => {
+    test('モックされたレスポンスから `prefName` を受け取って表示する', async () => {
+      render(<PrefectureName />);
+
+      const prefCode = await screen.findByText(/青森県/);
+
+      expect(prefCode).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/functional/PrefectureName/index.tsx
+++ b/src/components/functional/PrefectureName/index.tsx
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import useSWR from 'swr';
+
+import type { SuccessApiResponse } from '@/types/ApiResponse';
+
+// todo: API Route の動作確認に使用してから削除
+const PrefectureName = () => {
+  const { data, isLoading } = useSWR(
+    '/api/portfolio?prefCode=2&year=2012&matter=1&class=1',
+    async (url: string) => {
+      const response = await axios.get<SuccessApiResponse>(url);
+
+      return response.data;
+    },
+  );
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!data) {
+    return <div>Something went wrong</div>;
+  }
+
+  return <div>{`Prefecture Name: ${data.result.prefName}`}</div>;
+};
+
+export default PrefectureName;

--- a/src/mocks/fakeData.ts
+++ b/src/mocks/fakeData.ts
@@ -1,0 +1,102 @@
+import type { SuccessApiResponse } from '@/types/ApiResponse';
+
+export const fakeData: SuccessApiResponse[] = [
+  {
+    message: null,
+    result: {
+      prefCode: '2',
+      prefName: '青森県',
+      year: '2012',
+      matter: '1',
+      class: '1',
+      data: [
+        {
+          broadCode: '03',
+          broadName: '事務的職業',
+          middleCode: '',
+          middleName: '',
+          value: 82587,
+        },
+        {
+          broadCode: '11',
+          broadName: '運搬・清掃等の職業',
+          middleCode: '',
+          middleName: '',
+          value: 70401,
+        },
+        {
+          broadCode: '05',
+          broadName: 'サービスの職業',
+          middleCode: '',
+          middleName: '',
+          value: 47854,
+        },
+        {
+          broadCode: '04',
+          broadName: '販売の職業',
+          middleCode: '',
+          middleName: '',
+          value: 44988,
+        },
+        {
+          broadCode: '08',
+          broadName: '生産工程の職業',
+          middleCode: '',
+          middleName: '',
+          value: 40836,
+        },
+        {
+          broadCode: '02',
+          broadName: '専門的・技術的職業',
+          middleCode: '',
+          middleName: '',
+          value: 36027,
+        },
+        {
+          broadCode: '09',
+          broadName: '輸送・機械運転の職業',
+          middleCode: '',
+          middleName: '',
+          value: 15853,
+        },
+        {
+          broadCode: '10',
+          broadName: '建設・採掘の職業',
+          middleCode: '',
+          middleName: '',
+          value: 15511,
+        },
+        {
+          broadCode: '99',
+          broadName: '分類不能の職業',
+          middleCode: '',
+          middleName: '',
+          value: 9600,
+        },
+        {
+          broadCode: '07',
+          broadName: '農林漁業の職業',
+          middleCode: '',
+          middleName: '',
+          value: 3493,
+        },
+        {
+          broadCode: '06',
+          broadName: '保安の職業',
+          middleCode: '',
+          middleName: '',
+          value: 2548,
+        },
+        {
+          broadCode: '01',
+          broadName: '管理的職業',
+          middleCode: '',
+          middleName: '',
+          value: 502,
+        },
+      ],
+      allcount: 370200,
+      otherscount: 0,
+    },
+  },
+];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,1 +1,37 @@
-export const handlers = [];
+import { fakeData } from './fakeData';
+import { rest } from 'msw';
+
+import type { ApiResponse } from '@/types/ApiResponse';
+
+export const handlers = [
+  rest.get<ApiResponse>('/api/portfolio', (req, res, ctx) => {
+    // RESAS API で定義されている必須のクエリパラメータ
+    // 参考: https://opendata.resas-portal.go.jp/docs/api/v1/regionalEmploy/analysis/portfolio.html
+    const prefCode = req.url.searchParams.get('prefCode');
+    const year = req.url.searchParams.get('year');
+    const matter = req.url.searchParams.get('matter');
+    const category = req.url.searchParams.get('class');
+
+    const fakePortfolio = fakeData.find(({ result }) => {
+      return (
+        result.prefCode === prefCode &&
+        result.year === year &&
+        result.matter === matter &&
+        result.class === category
+      );
+    });
+
+    if (!fakePortfolio) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          statusCode: '400',
+          message: 'Validation Failed.',
+          description: '',
+        }),
+      );
+    }
+
+    return res(ctx.json(fakePortfolio));
+  }),
+];

--- a/src/types/ApiResponse.ts
+++ b/src/types/ApiResponse.ts
@@ -1,0 +1,14 @@
+import type { RegionalPortfolio } from '@/types/RegionalPortfolio';
+
+export type SuccessApiResponse = {
+  message: string | null;
+  result: RegionalPortfolio;
+};
+
+export type ErrorApiResponse = {
+  statusCode: string;
+  message: string;
+  description: string;
+};
+
+export type ApiResponse = SuccessApiResponse | ErrorApiResponse;

--- a/src/types/PortfolioData.ts
+++ b/src/types/PortfolioData.ts
@@ -1,0 +1,7 @@
+export type PortfolioData = {
+  broadCode: string;
+  broadName: string;
+  middleCode: string;
+  middleName: string;
+  value: number;
+};

--- a/src/types/RegionalPortfolio.ts
+++ b/src/types/RegionalPortfolio.ts
@@ -1,0 +1,12 @@
+import type { PortfolioData } from '@/types/PortfolioData';
+
+export type RegionalPortfolio = {
+  prefCode: string;
+  prefName: string;
+  year: string;
+  matter: string;
+  class: string;
+  data: PortfolioData[];
+  allcount: number;
+  otherscount: number;
+};


### PR DESCRIPTION
## 変更内容

MSW を用いたモックハンドラーを追加する。
また、その動作を確認するためのコンポーネントとテストを追加する。

issue: #1

## チェックリスト

- [x] API Route へのリクエストをモックするハンドラーを追加
- [x] 内部で API を叩くコンポーネントを追加
- [x] コンポーネントをテスト (取得したオブジェクトを使って、何らかの値を表示する)

