### PR TITLE
中間 API とモックを整備

### DIFF
--- a/src/mocks/fakeData/fakePortfolios.ts
+++ b/src/mocks/fakeData/fakePortfolios.ts
@@ -1,6 +1,6 @@
 import type { PortFolioApiResponseType } from '@/schemas/portfolioApiResponseSchema';
 
-export const fakeData: PortFolioApiResponseType[] = [
+export const fakePortfolios: PortFolioApiResponseType[] = [
   {
     message: null,
     result: {

--- a/src/mocks/fakeData/fakePrefectures.ts
+++ b/src/mocks/fakeData/fakePrefectures.ts
@@ -1,4 +1,6 @@
-export const fakePrefectures = {
+import type { PrefecturesApiResponseType } from '@/schemas/prefecturesApiResponseSchema';
+
+export const fakePrefectures: PrefecturesApiResponseType = {
   message: null,
   result: [
     {

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,6 @@
+import { portfolio } from './portfolio';
+import { prefectures } from './prefectures';
+
+import type { RestHandler } from 'msw';
+
+export const handlers: RestHandler[] = [portfolio, prefectures];

--- a/src/mocks/handlers/portfolio.ts
+++ b/src/mocks/handlers/portfolio.ts
@@ -1,10 +1,11 @@
-import { fakeData } from './fakeData';
+import { fakePortfolios } from '@/mocks/fakeData/fakePortfolios';
 import { rest } from 'msw';
 
 import type { PortFolioApiResponseType } from '@/schemas/portfolioApiResponseSchema';
 
-export const handlers = [
-  rest.get<PortFolioApiResponseType>('/api/portfolio', (req, res, ctx) => {
+export const portfolio = rest.get<PortFolioApiResponseType>(
+  '/api/portfolio',
+  (req, res, ctx) => {
     // RESAS API で定義されている必須のクエリパラメータ
     // 参考: https://opendata.resas-portal.go.jp/docs/api/v1/regionalEmploy/analysis/portfolio.html
     const prefCode = req.url.searchParams.get('prefCode');
@@ -12,7 +13,7 @@ export const handlers = [
     const matter = req.url.searchParams.get('matter');
     const category = req.url.searchParams.get('class');
 
-    const fakePortfolio = fakeData.find(({ result }) => {
+    const fakePortfolio = fakePortfolios.find(({ result }) => {
       return (
         result.prefCode === prefCode &&
         result.year === year &&
@@ -33,5 +34,5 @@ export const handlers = [
     }
 
     return res(ctx.json(fakePortfolio));
-  }),
-];
+  },
+);

--- a/src/mocks/handlers/prefectures.ts
+++ b/src/mocks/handlers/prefectures.ts
@@ -1,0 +1,11 @@
+import { fakePrefectures } from '@/mocks/fakeData/fakePrefectures';
+import { rest } from 'msw';
+
+import type { PrefecturesApiResponseType } from '@/schemas/prefecturesApiResponseSchema';
+
+export const prefectures = rest.get<PrefecturesApiResponseType>(
+  '/api/prefectures',
+  (_req, res, ctx) => {
+    return res(ctx.json(fakePrefectures));
+  },
+);

--- a/src/pages/api/prefectures/index.ts
+++ b/src/pages/api/prefectures/index.ts
@@ -1,0 +1,30 @@
+import {
+  prefecturesApiResponseSchema,
+  type PrefecturesApiResponseType,
+} from '@/schemas/prefecturesApiResponseSchema';
+import axios from 'axios';
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const handler = async (
+  _req: NextApiRequest,
+  res: NextApiResponse<PrefecturesApiResponseType>,
+) => {
+  const { data } = await axios.get<PrefecturesApiResponseType>(
+    'https://opendata.resas-portal.go.jp/api/v1/prefectures',
+    {
+      headers: {
+        'X-API-KEY': process.env.API_KEY,
+      },
+    },
+  );
+  const { success } = prefecturesApiResponseSchema.safeParse(data);
+
+  if (success) {
+    res.json(data);
+  } else {
+    res.status(400).end();
+  }
+};
+
+export default handler;

--- a/src/schemas/prefecturesApiResponseSchema.ts
+++ b/src/schemas/prefecturesApiResponseSchema.ts
@@ -1,0 +1,11 @@
+import { prefectureSchema } from './prefectureSchema';
+import z from 'zod';
+
+export const prefecturesApiResponseSchema = z.object({
+  message: z.string().nullable(),
+  result: z.array(prefectureSchema),
+});
+
+export type PrefecturesApiResponseType = z.infer<
+  typeof prefecturesApiResponseSchema
+>;


### PR DESCRIPTION
## 概要

[都道府県一覧 API](https://opendata.resas-portal.go.jp/docs/api/v1/prefectures.html) に対応する中間 API を追加する。

issue: #9

## チェックリスト

- [x] `/pages/api/prefectures` を実装
- [x] 中間 API がブラウザ環境で期待通りのレスポンスを返すことを確認
- [x] `mocks` 以下のファイルを整理 

